### PR TITLE
Provenance product offering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.woodpecker/.development.yml
+++ b/.woodpecker/.development.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_BRANCH}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [development]
+when:
+  event: push
+  branch: [development]

--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: feature/*
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [master, main]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
     secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  ref: refs/tags/v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:4.12.1 as builder
+FROM madnificent/ember:4.12.1-node_18 AS builder
 
 LABEL maintainer="info@redpencil.io"
 

--- a/app/components/product/edit.hbs
+++ b/app/components/product/edit.hbs
@@ -263,9 +263,6 @@
         </fieldset>
         <div class="mt-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.unitPriceSpecification.created}} @user={{@model.salesOffering.unitPriceSpecification.creator}} />
-          </div>
-          <div>
             <Util::UpdatedOn @date={{@model.salesOffering.unitPriceSpecification.modified}} @user={{@model.salesOffering.unitPriceSpecification.editor}} />
           </div>
         </div>

--- a/app/components/product/edit.hbs
+++ b/app/components/product/edit.hbs
@@ -263,10 +263,10 @@
         </fieldset>
         <div class="mt-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.created}} @user={{@model.salesOffering.creator}} />
+            <Util::CreatedOn @date={{@model.salesOffering.unitPriceSpecification.created}} @user={{@model.salesOffering.unitPriceSpecification.creator}} />
           </div>
           <div>
-            <Util::UpdatedOn @date={{@model.salesOffering.modified}} @user={{@model.salesOffering.editor}} />
+            <Util::UpdatedOn @date={{@model.salesOffering.unitPriceSpecification.modified}} @user={{@model.salesOffering.unitPriceSpecification.editor}} />
           </div>
         </div>
         {{/let}}

--- a/app/components/product/edit.hbs
+++ b/app/components/product/edit.hbs
@@ -76,6 +76,14 @@
                 class="mt-1 focus:ring-red-200 focus:border-red-200 block w-full border-gray-300 rounded-md sm:text-sm" />
              </div>
           </div>
+          <div class="mt-4 text-xs text-gray-400">
+            <div>
+              <Util::CreatedOn @date={{@model.created}} />
+            </div>
+            <div>
+              <Util::UpdatedOn @date={{@model.modified}} />
+            </div>
+          </div>
         </div>
         <div class="md:col-span-1">
           <div class="mt-8 border-t border-gray-200 pt-8 md:mt-0 md:border-0 md:pt-0">
@@ -253,8 +261,16 @@
             </div>
           </div>
         </fieldset>
-      {{/let}}
-    </div>
+        <div class="mt-4 text-xs text-gray-400">
+          <div>
+            <Util::CreatedOn @date={{@model.salesOffering.created}} />
+          </div>
+          <div>
+            <Util::UpdatedOn @date={{@model.salesOffering.modified}} />
+          </div>
+        </div>
+        {{/let}}
+      </div>
     <div class="mt-8 border-t border-gray-200 pt-8">
       <Util::SectionHeader
         @title="Bijlagen"
@@ -321,14 +337,6 @@
   </div>
   <div class="mt-8 border-t border-gray-200 pt-5">
     <div class="flex flex-wrap-reverse justify-between items-center">
-      <div class="mt-6 text-xs text-gray-400 sm:mt-0">
-        <div>
-          <Util::CreatedOn @date={{@model.created}} />
-        </div>
-        <div>
-          <Util::UpdatedOn @date={{@model.modified}} />
-        </div>
-      </div>
       <div class="flex justify-end space-x-3">
         <Rlv::Button
           @label="Annuleer"

--- a/app/components/product/edit.hbs
+++ b/app/components/product/edit.hbs
@@ -78,10 +78,10 @@
           </div>
           <div class="mt-4 text-xs text-gray-400">
             <div>
-              <Util::CreatedOn @date={{@model.created}} />
+              <Util::CreatedOn @date={{@model.created}} @user={{@model.creator}} />
             </div>
             <div>
-              <Util::UpdatedOn @date={{@model.modified}} />
+              <Util::UpdatedOn @date={{@model.modified}} @user={{@model.editor}} />
             </div>
           </div>
         </div>
@@ -263,10 +263,10 @@
         </fieldset>
         <div class="mt-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.created}} />
+            <Util::CreatedOn @date={{@model.salesOffering.created}} @user={{@model.salesOffering.creator}} />
           </div>
           <div>
-            <Util::UpdatedOn @date={{@model.salesOffering.modified}} />
+            <Util::UpdatedOn @date={{@model.salesOffering.modified}} @user={{@model.salesOffering.editor}} />
           </div>
         </div>
         {{/let}}

--- a/app/components/product/edit.js
+++ b/app/components/product/edit.js
@@ -91,7 +91,6 @@ export default class ProductEditComponent extends Component {
       ]);
       yield Promise.all([warehouseLocation.save(), purchasePrice.save(), salesPrice.save()]);
       yield Promise.all([purchaseOffering.save(), salesOffering.save()]);
-      this.args.model.modified = new Date();
       yield this.args.model.save();
 
       if (this.args.onSave) {

--- a/app/components/product/view.hbs
+++ b/app/components/product/view.hbs
@@ -72,10 +72,10 @@
         </div>
         <div class="mt-6 gap-y-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.created}} />
+            <Util::CreatedOn @date={{@model.created}} @user={{@model.creator}} />
           </div>
           <div>
-            <Util::UpdatedOn @date={{@model.modified}} />
+            <Util::UpdatedOn @date={{@model.modified}} @user={{@model.editor}} />
           </div>
         </div>
       </div>
@@ -192,10 +192,10 @@
         </div>
         <div class="mt-6 gap-y-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.created}} />
+            <Util::CreatedOn @date={{@model.salesOffering.created}} @user={{@model.salesOffering.creator}} />
           </div>
           <div>
-            <Util::UpdatedOn @date={{@model.salesOffering.modified}} />
+            <Util::UpdatedOn @date={{@model.salesOffering.modified}} @user={{@model.salesOffering.editor}} />
           </div>
         </div>
       </div>

--- a/app/components/product/view.hbs
+++ b/app/components/product/view.hbs
@@ -192,10 +192,10 @@
         </div>
         <div class="mt-6 gap-y-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.created}} @user={{@model.salesOffering.creator}} />
+            <Util::CreatedOn @date={{@model.salesOffering.unitPriceSpecification.created}} @user={{@model.salesOffering.unitPriceSpecification.creator}} />
           </div>
           <div>
-            <Util::UpdatedOn @date={{@model.salesOffering.modified}} @user={{@model.salesOffering.editor}} />
+            <Util::UpdatedOn @date={{@model.salesOffering.unitPriceSpecification.modified}} @user={{@model.salesOffering.unitPriceSpecification.editor}} />
           </div>
         </div>
       </div>

--- a/app/components/product/view.hbs
+++ b/app/components/product/view.hbs
@@ -70,6 +70,14 @@
             <Util::Property @label="Opmerking" @value={{@model.description}} />
           </div>
         </div>
+        <div class="mt-6 gap-y-4 text-xs text-gray-400">
+          <div>
+            <Util::CreatedOn @date={{@model.created}} />
+          </div>
+          <div>
+            <Util::UpdatedOn @date={{@model.modified}} />
+          </div>
+        </div>
       </div>
       <div class="md:col-span-1">
         <div class="mt-8 border-t border-gray-200 pt-8 md:mt-0 md:border-0 md:pt-0">
@@ -182,6 +190,14 @@
             </Util::Property>
           </div>
         </div>
+        <div class="mt-6 gap-y-4 text-xs text-gray-400">
+          <div>
+            <Util::CreatedOn @date={{@model.salesOffering.created}} />
+          </div>
+          <div>
+            <Util::UpdatedOn @date={{@model.salesOffering.modified}} />
+          </div>
+        </div>
       </div>
     {{/let}}
     <div class="mt-8 border-t border-gray-200 pt-8">
@@ -203,14 +219,6 @@
   </div>
   <div class="mt-8 border-t border-gray-200 pt-5">
     <div class="flex flex-wrap-reverse justify-between items-center">
-      <div class="mt-6 text-xs text-gray-400 sm:mt-0">
-        <div>
-          <Util::CreatedOn @date={{@model.created}} />
-        </div>
-        <div>
-          <Util::UpdatedOn @date={{@model.modified}} />
-        </div>
-      </div>
       <div class="flex justify-end space-x-3">
         <Rlv::Button
           @label="Terug"

--- a/app/components/product/view.hbs
+++ b/app/components/product/view.hbs
@@ -192,9 +192,6 @@
         </div>
         <div class="mt-6 gap-y-4 text-xs text-gray-400">
           <div>
-            <Util::CreatedOn @date={{@model.salesOffering.unitPriceSpecification.created}} @user={{@model.salesOffering.unitPriceSpecification.creator}} />
-          </div>
-          <div>
             <Util::UpdatedOn @date={{@model.salesOffering.unitPriceSpecification.modified}} @user={{@model.salesOffering.unitPriceSpecification.editor}} />
           </div>
         </div>

--- a/app/models/offering.js
+++ b/app/models/offering.js
@@ -8,6 +8,10 @@ export default class OfferingModel extends Model {
   @attr('string') availability;
   @attr('datetime') validFrom;
   @attr('datetime') validThrough;
+  @attr('datetime') created;
+  @attr('datetime') modified;
+  @attr('string') creator;
+  @attr('string') editor;
 
   @belongsTo('product', { inverse: 'purchaseOffering', async: true }) purchaseProduct;
   @belongsTo('product', { inverse: 'salesOffering', async: true }) salesProduct;

--- a/app/models/offering.js
+++ b/app/models/offering.js
@@ -1,9 +1,8 @@
-import { attr, belongsTo } from '@ember-data/model';
-import ProvenanceModel from './provenance-model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 import { isAfter } from 'date-fns';
 import { isPresent } from '@ember/utils';
 
-export default class OfferingModel extends ProvenanceModel {
+export default class OfferingModel extends Model {
   @attr('string') name;
   @attr('string') identifier;
   @attr('string') availability;

--- a/app/models/offering.js
+++ b/app/models/offering.js
@@ -1,17 +1,14 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import { attr, belongsTo } from '@ember-data/model';
+import ProvenanceModel from './provenance-model';
 import { isAfter } from 'date-fns';
 import { isPresent } from '@ember/utils';
 
-export default class OfferingModel extends Model {
+export default class OfferingModel extends ProvenanceModel {
   @attr('string') name;
   @attr('string') identifier;
   @attr('string') availability;
   @attr('datetime') validFrom;
   @attr('datetime') validThrough;
-  @attr('datetime') created;
-  @attr('datetime') modified;
-  @attr('string') creator;
-  @attr('string') editor;
 
   @belongsTo('product', { inverse: 'purchaseOffering', async: true }) purchaseProduct;
   @belongsTo('product', { inverse: 'salesOffering', async: true }) salesProduct;

--- a/app/models/product.js
+++ b/app/models/product.js
@@ -15,6 +15,8 @@ export default class ProductModel extends Model {
   @attr('boolean') includeInStockReport;
   @attr('datetime') created;
   @attr('datetime') modified;
+  @attr('string') creator;
+  @attr('string') editor;
 
   @belongsTo('warehouse-location', { inverse: 'products', async: true }) warehouseLocation;
   @belongsTo('offering', { inverse: 'purchaseProduct', async: true }) purchaseOffering;

--- a/app/models/product.js
+++ b/app/models/product.js
@@ -1,6 +1,7 @@
-import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+import { attr, hasMany, belongsTo } from '@ember-data/model';
+import ProvenanceModel from './provenance-model';
 
-export default class ProductModel extends Model {
+export default class ProductModel extends ProvenanceModel {
   @attr('language-string-set') name;
   @attr('language-string-set', {
     // even though we use ember-mu-transform-helpers, this default isn't covered
@@ -13,10 +14,6 @@ export default class ProductModel extends Model {
   @attr('string') description;
   @attr('number') identifier;
   @attr('boolean') includeInStockReport;
-  @attr('datetime') created;
-  @attr('datetime') modified;
-  @attr('string') creator;
-  @attr('string') editor;
 
   @belongsTo('warehouse-location', { inverse: 'products', async: true }) warehouseLocation;
   @belongsTo('offering', { inverse: 'purchaseProduct', async: true }) purchaseOffering;

--- a/app/models/provenance-model.js
+++ b/app/models/provenance-model.js
@@ -1,0 +1,24 @@
+import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
+
+export default class ProvenanceModel extends Model {
+  @service userInfo;
+
+  @attr('datetime') created;
+  @attr('datetime') modified;
+  @attr('string') creator;
+  @attr('string') editor;
+
+  save() {
+    const now = new Date();
+    if (this.isNew) {
+      this.created = now;
+      this.creator = this.userInfo.user.uri;
+    }
+    if (this.hasDirtyAttributes) {
+      this.modified = now;
+      this.editor = this.userInfo.user.uri;
+    }
+    return super.save(...arguments);
+  }
+}

--- a/app/models/unit-price-specification.js
+++ b/app/models/unit-price-specification.js
@@ -1,11 +1,12 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import { attr, belongsTo } from '@ember-data/model';
+import ProvenanceModel from './provenance-model';
 import { calculatePriceTaxIncluded, calculatePriceTaxExcluded } from '../utils/calculate-price';
 import constants from '../config/constants';
 import { VAT_RATE } from '../config';
 
 const { CALCULATION_BASIS } = constants;
 
-export default class UnitPriceSpecificationModel extends Model {
+export default class UnitPriceSpecificationModel extends ProvenanceModel {
   @attr('string') currency;
   @attr('number') currencyValue;
   @attr('number') margin;

--- a/app/routes/main/products/new.js
+++ b/app/routes/main/products/new.js
@@ -40,8 +40,6 @@ export default class MainProductsNewRoute extends Route {
     });
     const warehouseLocation = this.store.createRecord('warehouse-location', {});
     const product = this.store.createRecord('product', {
-      created: now,
-      modified: now,
       identifier: number,
       warehouseLocation,
       purchaseOffering,


### PR DESCRIPTION
Add provenance details for both product and pricing detail. Abstracted provenance data modification into a separate model.  
Added a `.dockerignore`-file for build shenanigans (adding `purge` to woodpecker config would work too I think, but to me, having `node_modules` in `.dockerignore` is the most explicit way to express that an existing `node_modules` may not be reused in a new build. )