### PR TITLE
Only show preview button if preview of product exists

### DIFF
--- a/app/controllers/main/products/list/index.js
+++ b/app/controllers/main/products/list/index.js
@@ -1,10 +1,12 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { trackedFunction } from 'reactiveweb/function';
+import { service } from '@ember/service';
 export default class MainProductsListIndexController extends Controller {
-
   @tracked previewProduct;
-  
+  @service store;
+
   @action
   showPreview(product) {
     this.previewProduct = product;
@@ -14,4 +16,18 @@ export default class MainProductsListIndexController extends Controller {
   closePreview() {
     this.previewProduct = undefined;
   }
+
+  hasPreview = (product) => {
+    return this.productIdsWithImages.value?.some(pId => pId === product.id);
+  }
+
+  productIdsWithImages = trackedFunction(this, async () => {
+    const searchProductIds = this.model.map((p) => p.id);
+    console.log(searchProductIds);
+    const productsWithImage = await this.store.query('product', {
+      'filter[:id:]': searchProductIds.join(','),
+      'filter[attachments][format]': 'image/',
+    });
+    return productsWithImage.map(p => p.id);
+  });
 }

--- a/app/templates/main/products/list/index.hbs
+++ b/app/templates/main/products/list/index.hbs
@@ -77,10 +77,12 @@
                     @route="main.products.detail.index"
                     @model={{product.uuid}}
                     @skin="link" />
-                  <Rlv::Button
-                    @label="Preview"
-                    @skin="link"
-                    {{on "click" (fn this.showPreview product)}} />
+                  {{#if (this.hasPreview product)}}
+                    <Rlv::Button
+                      @label="Preview"
+                      @skin="link"
+                      {{on "click" (fn this.showPreview product)}} />
+                  {{/if}}
                 </td>
               </tr>
             {{else}}


### PR DESCRIPTION
the previews are checked with a background task (so after the page is already shown to the user). It uses a mu-resources filter so no extra data has to be loaded.